### PR TITLE
allow quotes and double quotes setting tag value strings

### DIFF
--- a/pyexif/__init__.py
+++ b/pyexif/__init__.py
@@ -277,7 +277,11 @@ class ExifEditor(object):
             raise TypeError('tags_dict is not instance of dict')
         vallist = []
         for tag in tags_dict:
-            vallist.append("-{0}='{1}'".format(tag, tags_dict[tag]))
+            val = tags_dict[tag]
+            # escape double quotes in case of string type
+            if isinstance(val, basestring):
+                val = val.replace('"', '\\"')
+            vallist.append('-{0}="{1}"'.format(tag, val))
         valstr = " ".join(vallist)
         cmd = """exiftool {self._optExpr} {valstr} "{self.photo}" """.format(**locals())
         try:

--- a/pyexif/__init__.py
+++ b/pyexif/__init__.py
@@ -279,7 +279,7 @@ class ExifEditor(object):
         for tag in tags_dict:
             val = tags_dict[tag]
             # escape double quotes in case of string type
-            if isinstance(val, basestring):
+            if isinstance(val, six.string_types):
                 val = val.replace('"', '\\"')
             vallist.append('-{0}="{1}"'.format(tag, val))
         valstr = " ".join(vallist)

--- a/pyexif/__init__.py
+++ b/pyexif/__init__.py
@@ -256,7 +256,8 @@ class ExifEditor(object):
         """
         if not isinstance(val, (list, tuple)):
             val = [val]
-        vallist = ["-{0}='{1}'".format(tag, v) for v in val]
+        vallist = ['-{0}="{1}"'.format(tag,
+            v.replace('"', '\\"') if isinstance(v, six.string_types) else v) for v in val]
         valstr = " ".join(vallist)
         cmd = """exiftool {self._optExpr} {valstr} "{self.photo}" """.format(**locals())
         try:


### PR DESCRIPTION
I got
```
RuntimeError: /bin/sh: -c: line 0: unexpected EOF while looking for matching `''
/bin/sh: -c: line 1: syntax error: unexpected end of file

```
when I used a quote (') in a tag value string. So I have rewritten that a little bit ...